### PR TITLE
Update libghostty AppKit input fixes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "fc286d0829b7ad45c7e5da8ad634ed8e6571195e850cf5bc73eecb563c3f3f1b",
+  "originHash" : "053d0654ceae9bd0cbdfd594ed41a454d5d6885c4fdabb9e40de068dd0cb7b6f",
   "pins" : [
     {
       "identity" : "libghostty-spm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duxphp/libghostty-spm",
       "state" : {
-        "branch" : "pr/appkit-input-alignment",
-        "revision" : "31bd186b540774112e84c54971bfdd1ada81abea"
+        "branch" : "pr/appkit-shift-direct-input",
+        "revision" : "e4616e6897e86e057e1869d88e5c17876b8b1ed2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/duxphp/libghostty-spm", branch: "pr/appkit-input-alignment"),
+        .package(url: "https://github.com/duxphp/libghostty-spm", branch: "pr/appkit-shift-direct-input"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
     ],

--- a/dmux.xcodeproj/project.pbxproj
+++ b/dmux.xcodeproj/project.pbxproj
@@ -989,7 +989,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/duxphp/libghostty-spm";
 			requirement = {
-				branch = "pr/appkit-input-alignment";
+				branch = "pr/appkit-shift-direct-input";
 				kind = branch;
 			};
 		};

--- a/dmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a9d6714a8a673aa4a0a01242796652da4c8e1745f3cb833774e45307413a2790",
+  "originHash" : "b30216206b2a75b622f0a209d1d1434ac566865885a86b0e65c06468cec53e19",
   "pins" : [
     {
       "identity" : "libghostty-spm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duxphp/libghostty-spm",
       "state" : {
-        "branch" : "pr/appkit-input-alignment",
-        "revision" : "65149f9f1ad891f4b4cd366c3aa1c65724ea265f"
+        "branch" : "pr/appkit-shift-direct-input",
+        "revision" : "e4616e6897e86e057e1869d88e5c17876b8b1ed2"
       }
     },
     {


### PR DESCRIPTION
## Summary
- switch Codux to `duxphp/libghostty-spm` branch `pr/appkit-shift-direct-input`
- update both SwiftPM lockfiles to libghostty commit `e4616e6`
- pull in the generalized AppKit interpreted-command replay fix so keys like Shift-Tab reach Ghostty correctly

## Verification
- `swift test`
- `zsh ./dev.sh`
