### PR TITLE
fix: add terminal font family setting

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -756,6 +756,7 @@ dependencies = [
  "chrono",
  "core-foundation-sys",
  "dispatch2",
+ "fontdb",
  "futures-util",
  "genai",
  "git2",
@@ -902,6 +903,15 @@ dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1591,6 +1601,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -2805,6 +2838,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,6 +2971,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -4315,6 +4363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5154,6 +5208,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -6266,6 +6329,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "tungstenite"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ notify = "8.2.0"
 percent-encoding = "2.3"
 portable-pty = "0.9"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider", "system-proxy"] }
+fontdb = "0.23"
 futures-util = "0.3"
 genai = "0.6.1"
 git2 = { version = "0.21.0", features = ["cred", "https", "ssh", "vendored-openssl"] }

--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -46,6 +46,8 @@ pub struct AppSettings {
     pub theme_color: String,
     #[serde(default = "default_terminal_font_size")]
     pub terminal_font_size: String,
+    #[serde(default)]
+    pub terminal_font_family: String,
     #[serde(default = "default_terminal_scrollback_lines")]
     pub terminal_scrollback_lines: String,
     #[serde(default = "default_icon_style")]
@@ -391,6 +393,7 @@ impl Default for AppSettings {
             theme: default_theme(),
             theme_color: default_theme_color(),
             terminal_font_size: default_terminal_font_size(),
+            terminal_font_family: String::new(),
             terminal_scrollback_lines: default_terminal_scrollback_lines(),
             icon_style: default_icon_style(),
             notification_channels: HashMap::new(),
@@ -608,6 +611,13 @@ fn sanitize_settings(mut settings: AppSettings) -> AppSettings {
     if settings.terminal_font_size.trim().is_empty() {
         settings.terminal_font_size = default_terminal_font_size();
     }
+    settings.terminal_font_family = settings
+        .terminal_font_family
+        .chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
+        .trim()
+        .to_string();
     settings.terminal_scrollback_lines =
         sanitize_terminal_scrollback_lines(&settings.terminal_scrollback_lines);
     if settings.icon_style.trim().is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1089,6 +1089,20 @@ fn app_settings_get(state: tauri::State<'_, AppState>) -> AppSettings {
 }
 
 #[tauri::command]
+fn list_system_fonts() -> Vec<String> {
+    let mut db = fontdb::Database::new();
+    db.load_system_fonts();
+    let mut families: Vec<String> = db
+        .faces()
+        .flat_map(|f| f.families.first().map(|(name, _)| name.clone()))
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    families.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    families
+}
+
+#[tauri::command]
 fn app_settings_set(
     state: tauri::State<'_, AppState>,
     app: tauri::AppHandle,
@@ -6976,6 +6990,7 @@ pub fn run() {
             ai_runtime_dismiss_completion,
             app_settings_get,
             app_settings_set,
+            list_system_fonts,
             localized_open_dialog,
             localized_save_dialog,
             desktop_pet_placement,

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   readAppSettings,
   readTerminalFontSize,
+  readTerminalFontFamily,
   readTerminalScrollbackLines,
   subscribeAppSettings,
 } from "../settings";
@@ -38,6 +39,7 @@ type TerminalRendererAdapter = {
   fit: () => void;
   refreshTheme: () => void;
   setFontSize: (fontSize: number) => void;
+  setFontFamily: (fontFamily: string) => void;
   setScrollback: (lines: number) => void;
   setInputEnabled: (enabled: boolean) => void;
   copySelection: () => Promise<void>;
@@ -66,8 +68,6 @@ const LOCAL_INPUT_LOW_LATENCY_MS = 700;
 const STREAM_ANIMATION_QUEUE_BYTES = 64 * 1024;
 const isWindowsTerminal = isWindowsPlatform();
 const isMacTerminal = isMacPlatform();
-const TERMINAL_FONT_FAMILY =
-  '"Berkeley Mono", "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", "Noto Sans CJK SC", monospace';
 
 function cssVar(style: CSSStyleDeclaration, name: string, fallback: string) {
   return style.getPropertyValue(name).trim() || fallback;
@@ -162,7 +162,7 @@ function XtermRenderer({
       cursorInactiveStyle: "outline",
       disableStdin: true,
       drawBoldTextInBrightColors: true,
-      fontFamily: TERMINAL_FONT_FAMILY,
+      fontFamily: readTerminalFontFamily(),
       fontSize: readTerminalFontSize(),
       lineHeight: 1.25,
       macOptionIsMeta: true,
@@ -569,6 +569,11 @@ function XtermRenderer({
         terminal.options.fontSize = fontSize;
         scheduleFit(true);
       },
+      setFontFamily: (fontFamily) => {
+        if (terminal.options.fontFamily === fontFamily) return;
+        terminal.options.fontFamily = fontFamily;
+        scheduleFit(true);
+      },
       setScrollback: (lines) => {
         if (terminal.options.scrollback === lines) return;
         terminal.options.scrollback = lines;
@@ -897,6 +902,7 @@ export function TerminalView({
       if (!adapter) return;
       const settings = readAppSettings();
       adapter.setFontSize(readTerminalFontSize(settings));
+      adapter.setFontFamily(readTerminalFontFamily(settings));
       adapter.setScrollback(readTerminalScrollbackLines(settings));
       adapter.refreshTheme();
     };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,7 @@ export type AppSettings = {
   theme: string;
   themeColor: string;
   terminalFontSize: string;
+  terminalFontFamily: string;
   terminalScrollbackLines: string;
   iconStyle: string;
   notificationChannels: Record<string, NotificationChannelSettings>;
@@ -250,6 +251,7 @@ export const defaultSettings: AppSettings = {
   theme: "Auto",
   themeColor: "Blue",
   terminalFontSize: "14",
+  terminalFontFamily: "",
   terminalScrollbackLines: "500",
   iconStyle: "default",
   notificationChannels: {},
@@ -667,6 +669,16 @@ export function readTerminalFontSize(settings = readAppSettings()) {
   const parsed = Number(settings.terminalFontSize);
   if (!Number.isFinite(parsed)) return 14;
   return Math.max(10, Math.min(28, Math.round(parsed)));
+}
+
+const TERMINAL_FONT_FAMILY_FALLBACK =
+  '"Berkeley Mono", "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", "Noto Sans CJK SC", monospace';
+
+export function readTerminalFontFamily(settings = readAppSettings()) {
+  const custom = settings.terminalFontFamily.trim();
+  if (!custom) return TERMINAL_FONT_FAMILY_FALLBACK;
+  // Append fallback so CJK and monospace still resolve if custom font lacks those glyphs
+  return `${custom}, ${TERMINAL_FONT_FAMILY_FALLBACK}`;
 }
 
 export function readTerminalScrollbackLines(settings = readAppSettings()) {

--- a/src/windows/SettingsWindow.tsx
+++ b/src/windows/SettingsWindow.tsx
@@ -542,6 +542,10 @@ function shellOptionsForPlatform() {
 
 function AppearanceSection() {
   const [settings, setSettings] = useSyncedSettings();
+  const [systemFonts, setSystemFonts] = useState<string[]>([]);
+  useEffect(() => {
+    void invoke<string[]>("list_system_fonts").then(setSystemFonts).catch((err) => console.error("list_system_fonts failed:", err));
+  }, []);
   const selectedThemeColor = resolveThemeColorOption(settings.themeColor)?.label ?? settings.themeColor;
   const setSetting = <K extends keyof typeof settings>(key: K, value: (typeof settings)[K]) => {
     const next = updateAppSettings({ [key]: value });
@@ -610,6 +614,19 @@ function AppearanceSection() {
       </SettingsCard>
 
       <SettingsCard title={tm("settings.terminal_text", "Terminal Text")}>
+        <Field label={tm("settings.terminal_font_family", "Terminal Font Family")}>
+          <TextInput
+            placeholder="e.g. MesloLGS NF, Hack Nerd Font"
+            list="system-fonts-list"
+            value={settings.terminalFontFamily}
+            onChange={(event) => setSetting("terminalFontFamily", event.currentTarget.value)}
+          />
+          <datalist id="system-fonts-list">
+            {systemFonts.map((font) => (
+              <option key={font} value={font} />
+            ))}
+          </datalist>
+        </Field>
         <Field label={tm("settings.terminal_font_size", "Terminal Font Size")}>
           <TextInput
             type="number"


### PR DESCRIPTION
- Add under Settings → Appearance → Terminal Text
- Allow user to select front from list of system fonts

When left blank the existing font stack is used as-is. When a font name is entered (e.g. `MesloLGS NF`), it is prepended to the fallback stack so the system font resolves Nerd Font glyphs while CJK and generic monospace coverage is preserved.

The setting is applied live, no restart required.

close #21
 
<img width="810" height="676" alt="FontSettings" src="https://github.com/user-attachments/assets/a27e4b11-dac2-4978-8163-35bfbaa715ac" />
