### PR TITLE
Terminal renderer fix + configurable padding and smaller font sizes

### DIFF
--- a/apps/desktop/runtime/src/runtime_state/service_projects_settings/settings.rs
+++ b/apps/desktop/runtime/src/runtime_state/service_projects_settings/settings.rs
@@ -63,6 +63,10 @@ impl RuntimeService {
         self.update_settings_with_side_effects(|settings| settings.set_terminal_font_size(size))
     }
 
+    pub fn set_terminal_padding(&self, padding: &str) -> Result<SettingsSummary, String> {
+        self.update_settings_with_side_effects(|settings| settings.set_terminal_padding(padding))
+    }
+
     pub fn set_terminal_font_family(&self, family: &str) -> Result<SettingsSummary, String> {
         self.update_settings_with_side_effects(|settings| settings.set_terminal_font_family(family))
     }

--- a/apps/desktop/runtime/src/settings/app_settings/defaults.rs
+++ b/apps/desktop/runtime/src/settings/app_settings/defaults.rs
@@ -146,6 +146,10 @@ pub(super) fn default_terminal_font_size() -> String {
     "14".to_string()
 }
 
+pub(super) fn default_terminal_padding() -> String {
+    "0".to_string()
+}
+
 pub(super) fn default_terminal_scrollback_lines() -> String {
     "2000".to_string()
 }

--- a/apps/desktop/runtime/src/settings/app_settings/sanitize.rs
+++ b/apps/desktop/runtime/src/settings/app_settings/sanitize.rs
@@ -39,6 +39,9 @@ pub(super) fn sanitize_settings(mut settings: AppSettings) -> AppSettings {
     if settings.terminal_font_size.trim().is_empty() {
         settings.terminal_font_size = default_terminal_font_size();
     }
+    if settings.terminal_padding.trim().is_empty() {
+        settings.terminal_padding = default_terminal_padding();
+    }
     settings.terminal_scrollback_lines =
         sanitize_terminal_scrollback_lines(&settings.terminal_scrollback_lines);
     if settings.icon_style.trim().is_empty() {

--- a/apps/desktop/runtime/src/settings/app_settings/types.rs
+++ b/apps/desktop/runtime/src/settings/app_settings/types.rs
@@ -45,6 +45,8 @@ pub struct AppSettings {
     pub terminal_font_family: String,
     #[serde(default = "default_terminal_font_size")]
     pub terminal_font_size: String,
+    #[serde(default = "default_terminal_padding")]
+    pub terminal_padding: String,
     #[serde(default = "default_terminal_scrollback_lines")]
     pub terminal_scrollback_lines: String,
     #[serde(default = "default_terminal_paste_images_as_paths")]

--- a/apps/desktop/runtime/src/settings/app_settings/types/defaults_impl.rs
+++ b/apps/desktop/runtime/src/settings/app_settings/types/defaults_impl.rs
@@ -143,6 +143,7 @@ impl Default for AppSettings {
             theme_color: default_theme_color(),
             terminal_font_family: String::new(),
             terminal_font_size: default_terminal_font_size(),
+            terminal_padding: default_terminal_padding(),
             terminal_scrollback_lines: default_terminal_scrollback_lines(),
             terminal_paste_images_as_paths: default_terminal_paste_images_as_paths(),
             icon_style: default_icon_style(),

--- a/apps/desktop/runtime/src/settings/default_summary.rs
+++ b/apps/desktop/runtime/src/settings/default_summary.rs
@@ -10,6 +10,7 @@ impl Default for SettingsSummary {
             shows_dock_badge: true,
             terminal_font_family: String::new(),
             terminal_font_size: "14".to_string(),
+            terminal_padding: "0".to_string(),
             terminal_scrollback_lines: "2000".to_string(),
             terminal_paste_images_as_paths: true,
             file_open_default: "edit".to_string(),

--- a/apps/desktop/runtime/src/settings/service_preferences/terminal.rs
+++ b/apps/desktop/runtime/src/settings/service_preferences/terminal.rs
@@ -1,4 +1,15 @@
 impl SettingsService {
+    fn set_numeric_string(
+        &self,
+        key: &str,
+        value: &str,
+        default: i64,
+        min: i64,
+        max: i64,
+    ) -> Result<SettingsSummary, String> {
+        self.update_string(key, numeric_string(value, default, min, max).to_string())
+    }
+
     pub fn set_terminal_scrollback_lines(&self, lines: usize) -> Result<SettingsSummary, String> {
         self.update_string(
             "terminalScrollbackLines",
@@ -7,8 +18,11 @@ impl SettingsService {
     }
 
     pub fn set_terminal_font_size(&self, size: &str) -> Result<SettingsSummary, String> {
-        let size = numeric_string(size, 14, 10, 28).to_string();
-        self.update_string("terminalFontSize", size)
+        self.set_numeric_string("terminalFontSize", size, 14, 8, 28)
+    }
+
+    pub fn set_terminal_padding(&self, padding: &str) -> Result<SettingsSummary, String> {
+        self.set_numeric_string("terminalPadding", padding, 0, 0, 40)
     }
 
     pub fn set_terminal_font_family(&self, family: &str) -> Result<SettingsSummary, String> {
@@ -30,13 +44,13 @@ impl SettingsService {
     }
 
     pub fn set_terminal_scrollback_value(&self, lines: &str) -> Result<SettingsSummary, String> {
-        let lines = numeric_string(lines, 2000, 200, 10_000).to_string();
-        self.update_string("terminalScrollbackLines", lines)
+        self.set_numeric_string("terminalScrollbackLines", lines, 2000, 200, 10_000)
     }
 
     pub fn cycle_terminal_font_size(&self) -> Result<SettingsSummary, String> {
-        let current = numeric_string(&self.summary().terminal_font_size, 14, 10, 28);
+        let current = numeric_string(&self.summary().terminal_font_size, 14, 8, 28);
         let next = match current {
+            8 => 10,
             10 => 12,
             12 => 14,
             14 => 16,
@@ -44,7 +58,7 @@ impl SettingsService {
             18 => 20,
             20 => 24,
             24 => 28,
-            28 => 10,
+            28 => 8,
             _ => 14,
         };
         self.update_string("terminalFontSize", next.to_string())

--- a/apps/desktop/runtime/src/settings/summary.rs
+++ b/apps/desktop/runtime/src/settings/summary.rs
@@ -44,8 +44,13 @@ fn summary_from_raw(raw: &Map<String, Value>) -> SettingsSummary {
         terminal_font_size: raw
             .get("terminalFontSize")
             .and_then(Value::as_str)
-            .map(|value| numeric_string(value, 14, 10, 28).to_string())
+            .map(|value| numeric_string(value, 14, 8, 28).to_string())
             .unwrap_or(defaults.terminal_font_size),
+        terminal_padding: raw
+            .get("terminalPadding")
+            .and_then(Value::as_str)
+            .map(|value| numeric_string(value, 0, 0, 40).to_string())
+            .unwrap_or(defaults.terminal_padding),
         terminal_scrollback_lines: raw
             .get("terminalScrollbackLines")
             .and_then(Value::as_str)

--- a/apps/desktop/runtime/src/settings/types.rs
+++ b/apps/desktop/runtime/src/settings/types.rs
@@ -10,6 +10,7 @@ pub struct SettingsSummary {
     pub shows_dock_badge: bool,
     pub terminal_font_family: String,
     pub terminal_font_size: String,
+    pub terminal_padding: String,
     pub terminal_scrollback_lines: String,
     pub terminal_paste_images_as_paths: bool,
     pub file_open_default: String,

--- a/apps/desktop/src/app/settings.rs
+++ b/apps/desktop/src/app/settings.rs
@@ -31,6 +31,7 @@ use gpui_component::{
     switch::Switch,
 };
 use qrcode::{EcLevel, QrCode, types::Color as QrColor};
+use std::ops::RangeInclusive;
 
 const CODUX_MOBILE_DOWNLOAD_URL: &str = "https://codux.dux.cn/features/mobile/";
 const SETTINGS_FORM_TEXT_SIZE: Rems = Rems(0.875);
@@ -2048,6 +2049,20 @@ fn settings_general_pane(
                         cx,
                         language,
                         |app, value, window, cx| app.set_terminal_font_size(value, window, cx),
+                    ),
+                )
+                .into_any_element(),
+                settings_row(
+                    settings_text(language, "settings.terminal_padding", "Terminal Padding"),
+                    None,
+                    settings_select_impl(
+                        "settings-terminal-padding",
+                        &settings.terminal_padding,
+                        terminal_padding_options(),
+                        window,
+                        cx,
+                        language,
+                        |app, value, window, cx| app.set_terminal_padding(value, window, cx),
                     ),
                 )
                 .into_any_element(),
@@ -5077,13 +5092,21 @@ fn terminal_font_family_options(
     options
 }
 
-fn terminal_font_size_options() -> Vec<(String, SharedString)> {
-    (10..=28)
+fn numeric_range_options(range: RangeInclusive<i64>) -> Vec<(String, SharedString)> {
+    range
         .map(|value| {
             let value = value.to_string();
             (value.clone(), SharedString::from(value))
         })
         .collect()
+}
+
+fn terminal_font_size_options() -> Vec<(String, SharedString)> {
+    numeric_range_options(8..=28)
+}
+
+fn terminal_padding_options() -> Vec<(String, SharedString)> {
+    numeric_range_options(0..=40)
 }
 
 fn pet_speech_mode_options(language: &str) -> Vec<(String, SharedString)> {

--- a/apps/desktop/src/app/settings_actions.rs
+++ b/apps/desktop/src/app/settings_actions.rs
@@ -48,6 +48,29 @@ impl CoduxApp {
         self.invalidate_ui_region(cx, UiRegion::Root);
     }
 
+    pub(super) fn set_terminal_padding(
+        &mut self,
+        padding: String,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.state.settings.terminal_padding == padding {
+            return;
+        }
+        self.save_settings_async(
+            "set_terminal_padding",
+            "saving terminal padding",
+            move |service| service.set_terminal_padding(&padding),
+            |app, settings, cx| {
+                app.apply_async_settings_summary(settings);
+                app.apply_terminal_text_settings(cx);
+                app.invalidate_ui_region(cx, UiRegion::Root);
+            },
+            cx,
+        );
+        self.invalidate_ui_region(cx, UiRegion::Root);
+    }
+
     pub(super) fn set_terminal_scrollback_lines(
         &mut self,
         lines: String,

--- a/apps/desktop/src/app/terminal_state.rs
+++ b/apps/desktop/src/app/terminal_state.rs
@@ -23,7 +23,7 @@ use codux_runtime::{
     tool_permissions::ToolPermissionsSummary,
     worktree::WorktreeInfo,
 };
-use gpui::{WindowAppearance, px};
+use gpui::{Edges, WindowAppearance, px};
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 use uuid::Uuid;
@@ -1152,8 +1152,14 @@ pub(in crate::app) fn terminal_config_for_settings(
         .terminal_font_size
         .parse::<f32>()
         .unwrap_or(14.0)
-        .clamp(10.0, 28.0);
+        .clamp(8.0, 28.0);
     config.font_size = px(font_size);
+    let padding = settings
+        .terminal_padding
+        .parse::<f32>()
+        .unwrap_or(0.0)
+        .clamp(0.0, 40.0);
+    config.padding = Edges::all(px(padding));
     config.scrollback = settings
         .terminal_scrollback_lines
         .parse::<usize>()

--- a/apps/desktop/src/terminal/config.rs
+++ b/apps/desktop/src/terminal/config.rs
@@ -44,7 +44,7 @@ pub fn terminal_config() -> TerminalConfig {
         rows: 32,
         scrollback: 3_000,
         line_height_multiplier: DEFAULT_TERMINAL_LINE_HEIGHT_MULTIPLIER,
-        padding: Edges::all(px(10.0)),
+        padding: Edges::all(px(0.0)),
         colors,
         paste_images_as_paths: true,
         language: String::new(),
@@ -99,7 +99,7 @@ fn default_terminal_font_family() -> &'static str {
     }
 }
 
-const DEFAULT_TERMINAL_LINE_HEIGHT_MULTIPLIER: f32 = 1.45;
+const DEFAULT_TERMINAL_LINE_HEIGHT_MULTIPLIER: f32 = 1.2;
 const TERMINAL_SCROLL_FRAME_INTERVAL: Duration = Duration::from_millis(16);
 const TERMINAL_OUTPUT_FRAME_INTERVAL: Duration = Duration::from_millis(16);
 // Cap on how many output bytes are fed to the VT engine in a single flush.

--- a/apps/desktop/src/terminal/element.rs
+++ b/apps/desktop/src/terminal/element.rs
@@ -198,7 +198,7 @@ struct TerminalPreparedRow {
     background_rects: Vec<TerminalBackgroundRect>,
     graphics: Vec<TerminalGraphicCell>,
     text_runs: Vec<TerminalTextRun>,
-    line: Option<TerminalRowLine>,
+    lines: Vec<TerminalRowLine>,
 }
 
 impl TerminalPreparedRow {
@@ -213,7 +213,7 @@ impl TerminalPreparedRow {
         for text_run in &mut prepared.text_runs {
             text_run.row = row;
         }
-        if let Some(line) = &mut prepared.line {
+        for line in &mut prepared.lines {
             line.row = row;
         }
         prepared

--- a/apps/desktop/src/terminal/grid_version.rs
+++ b/apps/desktop/src/terminal/grid_version.rs
@@ -144,8 +144,9 @@ mod grid_version_tests {
             test_text_run(0, 2, "ab", false),
             test_text_run(2, 2, "CD", true),
         ];
-        let line = combine_terminal_row_runs(&runs, test_gap_font(), test_gap_color())
-            .expect("simple row combines");
+        let (lines, leftover) = combine_terminal_row_runs(runs, test_gap_font(), test_gap_color());
+        assert!(leftover.is_empty(), "both spans should combine");
+        let line = lines.into_iter().next().expect("simple row combines");
         assert_eq!(line.text, "abCD");
         assert_eq!(line.start_col, 0);
         assert_eq!(line.runs.len(), 2, "two style runs, one shaped line");
@@ -164,7 +165,11 @@ mod grid_version_tests {
             test_text_run(0, 2, "ab", false),
             test_text_run(5, 2, "CD", false),
         ];
-        let line = combine_terminal_row_runs(&runs, test_gap_font(), test_gap_color())
+        let (lines, leftover) = combine_terminal_row_runs(runs, test_gap_font(), test_gap_color());
+        assert!(leftover.is_empty(), "both spans should combine");
+        let line = lines
+            .into_iter()
+            .next()
             .expect("simple row with a gap combines");
         assert_eq!(line.text, "ab   CD"); // 3-column gap -> 3 spaces
         assert_eq!(
@@ -180,7 +185,9 @@ mod grid_version_tests {
         // re-flow by natural advance and break grid alignment, so it must keep
         // the per-span path.
         let runs = vec![test_text_run(0, 2, "中", false)];
-        assert!(combine_terminal_row_runs(&runs, test_gap_font(), test_gap_color()).is_none());
+        let (lines, leftover) = combine_terminal_row_runs(runs, test_gap_font(), test_gap_color());
+        assert!(lines.is_empty());
+        assert_eq!(leftover.len(), 1);
     }
 
     #[test]
@@ -188,7 +195,65 @@ mod grid_version_tests {
         // Defensive: a cell whose text is more than one char for one column
         // (e.g. a grapheme cluster) is not a 1:1 char/cell mapping.
         let runs = vec![test_text_run(0, 1, "a\u{0301}", false)]; // "á" as a + combining accent
-        assert!(combine_terminal_row_runs(&runs, test_gap_font(), test_gap_color()).is_none());
+        let (lines, leftover) = combine_terminal_row_runs(runs, test_gap_font(), test_gap_color());
+        assert!(lines.is_empty());
+        assert_eq!(leftover.len(), 1);
+    }
+
+    #[test]
+    fn combining_mark_cell_stays_in_one_paint_segment() {
+        // A cell whose text is a base char plus a combining mark (e.g. "á" as
+        // "a" + U+0301) must be shaped and painted as one unit at its own
+        // column, not split per Rust `char` — otherwise the mark would be
+        // displaced into the next column instead of stacking on the base.
+        let run = test_text_run(3, 1, "a\u{0301}", false);
+        assert_eq!(run.segments.len(), 1, "one cell, one paint segment");
+        assert_eq!(run.segments[0].col, 3);
+        assert_eq!(
+            &run.text[run.segments[0].byte_start..][..run.segments[0].byte_len],
+            "a\u{0301}"
+        );
+    }
+
+    #[test]
+    fn merged_run_keeps_one_segment_per_originating_cell() {
+        // Simple (1:1 char-to-cell) ASCII cells can be merged into one run's
+        // `text` buffer, but each originating cell keeps its own segment so a
+        // later non-ASCII cell appended to the same run (e.g. after further
+        // upstream changes) would still be positioned by cell, not by char.
+        let mut run = test_text_run(0, 1, "a", false);
+        run.append_text("b", 1);
+        run.append_text("c", 1);
+        assert_eq!(run.text, "abc");
+        assert_eq!(run.segments.len(), 3);
+        assert_eq!(
+            run.segments.iter().map(|s| s.col).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn combine_keeps_combining_around_a_noncombinable_span() {
+        // A wide/non-combinable span in the middle of a row must not block the
+        // ASCII spans before and after it from still combining into their own
+        // shaped lines.
+        let runs = vec![
+            test_text_run(0, 2, "ab", false),
+            test_text_run(2, 2, "CD", false),
+            test_text_run(4, 2, "中", false),
+            test_text_run(6, 2, "ef", false),
+            test_text_run(8, 2, "GH", false),
+        ];
+        let (lines, leftover) = combine_terminal_row_runs(runs, test_gap_font(), test_gap_color());
+        assert_eq!(leftover.len(), 1, "only the wide span stays per-span");
+        assert_eq!(leftover[0].text, "中");
+        assert_eq!(
+            lines.len(),
+            2,
+            "spans before and after the wide span each combine"
+        );
+        assert_eq!(lines[0].text, "abCD");
+        assert_eq!(lines[1].text, "efGH");
     }
 
     #[test]

--- a/apps/desktop/src/terminal/renderer.rs
+++ b/apps/desktop/src/terminal/renderer.rs
@@ -185,7 +185,7 @@ impl TerminalRenderer {
                 background_rects.extend(prepared.background_rects);
                 graphics.extend(prepared.graphics);
                 text_runs.extend(prepared.text_runs);
-                lines.extend(prepared.line);
+                lines.extend(prepared.lines);
             }
             let cursor_line = content.viewport_start_line + content.cursor.row as i32;
             if content.display_row_for_line(cursor_line) == Some(row) {
@@ -377,17 +377,17 @@ impl TerminalRenderer {
         let mut text_runs = Vec::new();
         self.prepare_row_backgrounds(0, cells, default_bg, &mut background_rects);
         self.prepare_row_text(0, cells, &mut text_runs, &mut graphics, None);
-        // Prefer a single shaped line for simple rows; on success the per-span
-        // runs are dropped so the row is shaped/painted once instead of N times.
-        let line = self.combine_row_runs(&text_runs);
-        if line.is_some() {
-            text_runs.clear();
-        }
+        // Combine maximal contiguous runs of simple (1:1 char-to-cell, ASCII)
+        // spans into single shaped lines, so the row is shaped/painted once
+        // instead of once per span; any remaining wide/multi-codepoint/
+        // non-ASCII spans stay in text_runs and are painted per-span. One such
+        // span no longer blocks the rest of the row from combining.
+        let (lines, text_runs) = self.combine_row_runs(text_runs);
         let prepared = TerminalPreparedRow {
             background_rects,
             graphics,
             text_runs,
-            line,
+            lines,
         };
         let mut cache = self.cache.lock();
         if cache.rows.len() > TERMINAL_ROW_CACHE_LIMIT {
@@ -690,6 +690,22 @@ impl TerminalRenderer {
     }
 }
 
+/// One originating terminal cell's byte range within a `TerminalTextRun`'s
+/// `text`. A cell's text can hold more than one codepoint (a base character
+/// plus combining/zero-width marks attached by the terminal model), so cells
+/// must be shaped and painted as a whole unit at `col` rather than split by
+/// Rust `char` — splitting would displace combining marks into the next
+/// column instead of stacking them on the base glyph. `hash` is computed once
+/// when the cell's text is appended so paint can hit the shape cache without
+/// re-hashing every frame.
+#[derive(Clone, Copy)]
+struct TerminalTextSegment {
+    col: usize,
+    byte_start: usize,
+    byte_len: usize,
+    hash: u64,
+}
+
 #[derive(Clone)]
 struct TerminalTextRun {
     row: usize,
@@ -698,6 +714,7 @@ struct TerminalTextRun {
     text: String,
     style: TextRun,
     text_hash: u64,
+    segments: Vec<TerminalTextSegment>,
 }
 
 impl TerminalTextRun {
@@ -709,6 +726,12 @@ impl TerminalTextRun {
         style: TextRun,
     ) -> Self {
         let text_hash = terminal_text_run_hash(&text);
+        let segments = vec![TerminalTextSegment {
+            col: start_col,
+            byte_start: 0,
+            byte_len: text.len(),
+            hash: text_hash,
+        }];
         Self {
             row,
             start_col,
@@ -716,6 +739,7 @@ impl TerminalTextRun {
             text,
             style,
             text_hash,
+            segments,
         }
     }
 
@@ -749,7 +773,16 @@ impl TerminalTextRun {
     }
 
     fn append_text(&mut self, text: &str, width_cols: usize) {
+        let byte_start = self.text.len();
+        let col = self.start_col + self.width_cols;
+        let hash = terminal_text_run_hash(text);
         self.text.push_str(text);
+        self.segments.push(TerminalTextSegment {
+            col,
+            byte_start,
+            byte_len: text.len(),
+            hash,
+        });
         self.width_cols += width_cols;
         self.style.len += text.len();
         self.text_hash = terminal_text_run_hash(&self.text);
@@ -762,30 +795,62 @@ impl TerminalTextRun {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let run = TextRun {
-            len: self.text.len(),
-            ..self.style.clone()
-        };
-        let text = self.text.as_str();
-        let shaped = window.text_system().shape_line_by_hash(
-            self.text_hash,
-            text.len(),
-            renderer.font_size,
-            &[run],
-            None,
-            || SharedString::from(text.to_string()),
-        );
-        let _ = shaped.paint(
-            Point {
-                x: origin.x + renderer.cell_width * self.start_col as f32,
-                y: origin.y + renderer.cell_height * self.row as f32,
-            },
-            renderer.cell_height,
-            TextAlign::Left,
-            None,
-            window,
-            cx,
-        );
+        if self.text.is_ascii() {
+            let run = TextRun {
+                len: self.text.len(),
+                ..self.style.clone()
+            };
+            let text = self.text.as_str();
+            let shaped = window.text_system().shape_line_by_hash(
+                self.text_hash,
+                text.len(),
+                renderer.font_size,
+                &[run],
+                None,
+                || SharedString::from(text.to_string()),
+            );
+            let _ = shaped.paint(
+                Point {
+                    x: origin.x + renderer.cell_width * self.start_col as f32,
+                    y: origin.y + renderer.cell_height * self.row as f32,
+                },
+                renderer.cell_height,
+                TextAlign::Left,
+                None,
+                window,
+                cx,
+            );
+            return;
+        }
+        // Non-ASCII text may trigger font fallback with advances that differ
+        // from cell_width, so each originating cell is shaped and positioned
+        // individually rather than as one natural-advance line. Painting by
+        // `segments` (one per cell) rather than by `char` keeps a cell's base
+        // character and any combining marks together as a single shaped unit.
+        for segment in &self.segments {
+            let chunk = &self.text[segment.byte_start..segment.byte_start + segment.byte_len];
+            let mut run = self.style.clone();
+            run.len = chunk.len();
+            let shaped = window.text_system().shape_line_by_hash(
+                segment.hash,
+                chunk.len(),
+                renderer.font_size,
+                &[run],
+                None,
+                || SharedString::from(chunk.to_string()),
+            );
+            let _ = shaped.paint(
+                Point {
+                    x: origin.x + renderer.cell_width * segment.col as f32,
+                    y: origin.y + renderer.cell_height * self.row as f32,
+                },
+                renderer.cell_height,
+                TextAlign::Left,
+                None,
+                window,
+                cx,
+            );
+        }
     }
 }
 
@@ -795,12 +860,13 @@ fn terminal_text_run_hash(text: &str) -> u64 {
     hasher.finish()
 }
 
-/// One terminal row painted as a single shaped line carrying multiple style
-/// runs, so GPUI shapes and paints it once per row instead of once per style
-/// span. Only built for "simple" rows (every painted cell is a single-codepoint,
-/// width-1 glyph) so the natural glyph advances line up exactly with the cell
-/// grid; rows with wide (CJK) or multi-codepoint cells fall back to the
-/// per-span path to keep grid alignment intact.
+/// A maximal run of a row's "simple" spans (single-codepoint, width-1,
+/// ASCII glyphs) painted as a single shaped line carrying multiple style
+/// runs, so GPUI shapes and paints them once instead of once per style span.
+/// A row can contain several of these interleaved with per-span spans (wide
+/// CJK or multi-codepoint cells) that must keep the per-span path to hold
+/// grid alignment — one such span no longer prevents the rest of the row
+/// from combining.
 #[derive(Clone)]
 struct TerminalRowLine {
     row: usize,
@@ -859,29 +925,76 @@ fn terminal_row_line_layout_hash(text: &str, runs: &[TextRun]) -> u64 {
 }
 
 impl TerminalRenderer {
-    /// Combine a row's already-built per-span runs into a single shaped line,
-    /// filling inter-span column gaps with spaces. Returns `None` (keeping the
-    /// per-span path) when any span is not a 1:1 char-to-cell run, so wide/CJK
-    /// rows are never re-flowed by natural advances.
-    fn combine_row_runs(&self, runs: &[TerminalTextRun]) -> Option<TerminalRowLine> {
+    /// Combine a row's already-built per-span runs into as few shaped lines as
+    /// possible: maximal contiguous groups of 1:1 char-to-cell ASCII spans are
+    /// merged into a `TerminalRowLine` each (so those spans are shaped/painted
+    /// once instead of once per span), while any wide (CJK), multi-codepoint,
+    /// or non-ASCII span is returned unmodified in the leftover run list to
+    /// keep the per-span path — without forcing the rest of the row's simple
+    /// spans to give up combining too.
+    fn combine_row_runs(
+        &self,
+        runs: Vec<TerminalTextRun>,
+    ) -> (Vec<TerminalRowLine>, Vec<TerminalTextRun>) {
         combine_terminal_row_runs(runs, self.font(false, false), self.palette.foreground())
     }
 }
 
 fn combine_terminal_row_runs(
-    runs: &[TerminalTextRun],
+    runs: Vec<TerminalTextRun>,
     gap_font: Font,
+    gap_color: Hsla,
+) -> (Vec<TerminalRowLine>, Vec<TerminalTextRun>) {
+    let mut lines = Vec::new();
+    let mut leftover = Vec::new();
+    let mut group: Vec<TerminalTextRun> = Vec::new();
+
+    for run in runs {
+        // Only 1:1 char-to-cell ASCII spans are safe to re-flow as one shaped
+        // line by natural glyph advances; wide (CJK) or multi-codepoint cells
+        // keep their own grid columns, and non-ASCII text may trigger font
+        // fallback with advances that differ from cell_width.
+        if run.text.chars().count() == run.width_cols && run.text.is_ascii() {
+            group.push(run);
+            continue;
+        }
+        flush_combinable_group(&mut group, &gap_font, gap_color, &mut lines, &mut leftover);
+        leftover.push(run);
+    }
+    flush_combinable_group(&mut group, &gap_font, gap_color, &mut lines, &mut leftover);
+
+    (lines, leftover)
+}
+
+/// Turns a maximal group of combinable spans into one `TerminalRowLine`
+/// (dropping the group), or moves it to `leftover` unchanged when it's too
+/// small to be worth combining (or, defensively, if building the line fails).
+fn flush_combinable_group(
+    group: &mut Vec<TerminalTextRun>,
+    gap_font: &Font,
+    gap_color: Hsla,
+    lines: &mut Vec<TerminalRowLine>,
+    leftover: &mut Vec<TerminalTextRun>,
+) {
+    if group.len() < 2 {
+        leftover.append(group);
+        return;
+    }
+    match build_terminal_row_line(group, gap_font, gap_color) {
+        Some(line) => {
+            lines.push(line);
+            group.clear();
+        }
+        None => leftover.append(group),
+    }
+}
+
+fn build_terminal_row_line(
+    runs: &[TerminalTextRun],
+    gap_font: &Font,
     gap_color: Hsla,
 ) -> Option<TerminalRowLine> {
     let first = runs.first()?;
-    // Only 1:1 char-to-cell spans are safe to re-flow as one line; wide (CJK) or
-    // multi-codepoint cells keep the per-span path so their grid columns hold.
-    if runs
-        .iter()
-        .any(|run| run.text.chars().count() != run.width_cols)
-    {
-        return None;
-    }
     let row = first.row;
     let start_col = first.start_col;
     let mut text = String::new();

--- a/apps/mobile/lib/models/remote_models.dart
+++ b/apps/mobile/lib/models/remote_models.dart
@@ -846,6 +846,8 @@ class MobileSettings {
   static const standardTerminalFontSize = 14.0;
   static const List<double> appTextScaleSteps = [0.875, 1.0, 1.125];
   static const List<double> terminalFontSizeSteps = [
+    10.0,
+    11.0,
     12.0,
     13.0,
     14.0,

--- a/apps/mobile/lib/widgets/components/remote_terminal_pane.dart
+++ b/apps/mobile/lib/widgets/components/remote_terminal_pane.dart
@@ -158,7 +158,7 @@ class _RemoteTerminalPaneState extends State<RemoteTerminalPane> {
         : 0.0;
     // Inset the terminal grid from the panel edges so the content isn't flush
     // against the surrounding container.
-    const terminalPadding = EdgeInsets.all(12);
+    const terminalPadding = EdgeInsets.all(4);
 
     return MediaQuery.removeViewInsets(
       context: context,

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -320,10 +320,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -749,10 +749,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Two terminal-focused changes, atomically committed.

### 1. `fix:` shape non-ASCII terminal cells per-segment to preserve combining marks
The row combiner previously gave up on the **entire row** as soon as one span was non-combinable (wide CJK, multi-codepoint, or anything non-ASCII), forcing the whole row through the slower per-span path.

- `combine_terminal_row_runs` now collects maximal contiguous groups of 1:1 char-to-cell ASCII spans and merges each group into its own `TerminalRowLine`, returning only genuinely non-combinable spans as leftover. One wide cell no longer blocks the rest of the row from combining.
- `TerminalTextRun` now carries one `TerminalTextSegment` per originating cell (byte range + column + hash). Non-ASCII text is painted per **cell** instead of per Rust `char`, so a cell's base character and any combining marks (e.g. `"á"` as `a` + `U+0301`) shape as a single unit at the correct column. The previous char-based split displaced combining marks into the next column.
- ASCII text keeps the fast single-shape path; only non-ASCII segments iterate.
- `TerminalPreparedRow.line: Option<_>` → `lines: Vec<_>` to carry multiple combined lines per row.
- New unit tests cover combining-mark cells, per-cell segment bookkeeping under `append_text`, and combining around a non-combinable span.

### 2. `feat:` configurable terminal padding and smaller font sizes
- New **`terminalPadding`** setting (0-40 px), plumbed end-to-end: `AppSettings`, sanitize, defaults, `SettingsSummary`, the settings service (`set_terminal_padding`), desktop settings UI (new select row), and `terminal_config_for_settings` (`Edges::all(px(padding))`).
- Static `terminal_config()` padding default drops from 10 px → 0 px so the user setting is the sole source of truth (the desktop pane insets were already adding their own padding, this avoids double-counting).
- Minimum terminal font size drops **10 → 8** across the cycle list, `numeric_string` bounds, and the desktop picker (`8..=28`). Mobile gains `10.0` and `11.0` steps and its remote-pane insets shrink `12 → 4` to match the tighter desktop layout.
- Default terminal line-height multiplier **1.45 → 1.2** — the old value left oversized row gaps at the new smaller sizes.
- Refactor: runtime terminal settings service routes numeric-string clamping through a shared `set_numeric_string` helper.

## Files
- `apps/desktop/src/terminal/{renderer,grid_version,element}.rs` — renderer fix
- `apps/desktop/runtime/src/settings/**`, `apps/desktop/src/app/{settings,settings_actions,terminal_state}.rs`, `apps/desktop/src/terminal/config.rs` — padding feature
- `apps/mobile/lib/{models/remote_models.dart, widgets/components/remote_terminal_pane.dart}`, `apps/mobile/pubspec.lock` — mobile alignment

## Test plan
- [ ] Desktop: terminal renders ASCII rows correctly (no regression in the combine path).
- [ ] Desktop: CJK / wide cells keep grid alignment; combining diacritics stack on the base glyph.
- [ ] Desktop: change Terminal Padding in settings → applies live, persists across restart.
- [ ] Desktop: cycle font size reaches 8 and wraps back from 28 → 8.
- [ ] Mobile: font picker shows 10.0/11.0 steps; terminal pane insets look correct.

## Notes
- Skipped two untracked items that do not belong in this PR: `.omo/` (local agent session state) and `docs/spec/changes/add-tailscale-transport-2026-07-05/` (a proposed but unrelated tailscale transport spec).

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)